### PR TITLE
Making the (action, element) tuple a namedtuple

### DIFF
--- a/pyosm/model.py
+++ b/pyosm/model.py
@@ -7,6 +7,7 @@ Way = collections.namedtuple('Way', 'id, version, changeset, user, uid, visible,
 Relation = collections.namedtuple('Relation', 'id, version, changeset, user, uid, visible, timestamp, members, tags')
 Member = collections.namedtuple('Member', 'type, ref, role')
 Changeset = collections.namedtuple('Changeset', 'id, created_at, closed_at, open, min_lat, max_lat, min_lon, max_lon, user, uid, tags')
+ActionElement = collections.namedtuple('ActionElement', 'Action, Element')
 
 ## Notes
 Note = collections.namedtuple('Note', 'id, lat, lon, created_at, closed_at, status, comments')

--- a/pyosm/parsing.py
+++ b/pyosm/parsing.py
@@ -195,13 +195,13 @@ def iter_osm_change_file(f, parse_timestamps=True):
                 action = elem.tag
         elif event == 'end':
             if elem.tag == 'node':
-                yield (action, obj)
+                yield models.ActionElement(action, obj
                 obj = None
             elif elem.tag == 'way':
-                yield (action, obj)
+                yield model.ActionElement(action, obj)
                 obj = None
             elif elem.tag == 'relation':
-                yield (action, obj)
+                yield model.ActionElement(action, obj)
                 obj = None
             elif elem.tag in ('create', 'modify', 'delete'):
                 action = None


### PR DESCRIPTION
This change just makes the tuple with the (action, element) into an explicit namedtuple, so it's able to be identified in the future.
